### PR TITLE
Feature/sessionKeyInQueryString config flag

### DIFF
--- a/__mocks__/isomorphic-unfetch.js
+++ b/__mocks__/isomorphic-unfetch.js
@@ -1,0 +1,6 @@
+const fetch = require('isomorphic-unfetch');
+
+// useful to track fetch calls
+const mockedFetch = jest.fn(fetch);
+
+module.exports = mockedFetch;

--- a/src/apiHelper.js
+++ b/src/apiHelper.js
@@ -13,8 +13,8 @@ const getForwardedForHeader = ({ ip }) => {
   return { 'X-FORWARDED-FOR': ip };
 };
 
-const getSessionHeader = ({ sessionKey }) => {
-  if (!sessionKey) {
+const getSessionHeader = ({ sessionKey, sessionKeyInQueryString }) => {
+  if (!sessionKey || sessionKeyInQueryString) {
     return {};
   }
   return { 'X-SESSION': sessionKey };
@@ -33,6 +33,11 @@ const getQueryString = (config, existingQs = {}) => {
   if (config.gid) {
     defaultQs.gid = config.gid;
   }
+
+  if (config.sessionKey && config.sessionKeyInQueryString) {
+    defaultQs.sessionKey = config.sessionKey;
+  }
+
   const qsObject = Object.assign({}, existingQs, defaultQs);
   const queryString = qs.stringify(qsObject);
   return queryString;

--- a/src/node/client.js
+++ b/src/node/client.js
@@ -17,7 +17,7 @@ const checkUsability = ({ appKey, deviceId, sessionKey } = {}) =>
 
 // Refer to `./index` for the doc
 const makeAccedoOne = stamp => config => {
-  const { gid, appKey, ip, target } = config;
+  const { gid, appKey, ip, target, sessionKeyInQueryString } = config;
   const {
     log = noop,
     onDeviceIdGenerated = noop,
@@ -49,6 +49,7 @@ const makeAccedoOne = stamp => config => {
     target,
     log,
     onSessionKeyChanged,
+    sessionKeyInQueryString,
   };
   Object.defineProperty(stampConfig, 'sessionKey', {
     set(val) {

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -16,6 +16,7 @@ const stamp = commonStamps.compose(appLogNode);
  * @param  {string} [config.ip] the user's IP, given to Accedo One for every request this client will trigger (for geolocation).
  * @param  {function} [config.log] a function to use to see this SDK's logs
  * @param  {function} [config.onDeviceIdGenerated] callback to obtain the new deviceId, if one gets generated
+ * @param  {boolean} [config.sessionKeyInQueryString] when truthy, will pass sessionKey in query string instead of X-SESSION header
  * @param  {function} [config.onSessionKeyChanged] callback to obtain the sessionKey, anytime a new one gets generated
  * @param  {string} [config.target] all APIs calls will use this as the base API URL (defaults to the Accedo One API URL)
  * @return {client}        an Accedo One client tied to the given params

--- a/test/specs/session.spec.js
+++ b/test/specs/session.spec.js
@@ -32,6 +32,16 @@ describe('Session API Tests', () => {
     expect(typeof key).toBe('string');
   });
 
+  describe('With truthy sessionKeyInQueryString flag...', () => {
+    test('should have empty headers', () => {});
+    test('should have sessionKey in query params', () => {});
+  });
+
+  describe('With falsy sessionKeyInQueryString flag...', () => {
+    test('should have X-SESSION header', () => {});
+    test('should have no sessionKey in query params', () => {});
+  });
+
   describe('With concurrent calls by one same client...', () => {
     const onSessionKeyChangedB = jest.fn();
     const clientB = factory({

--- a/test/specs/session.spec.js
+++ b/test/specs/session.spec.js
@@ -32,16 +32,6 @@ describe('Session API Tests', () => {
     expect(typeof key).toBe('string');
   });
 
-  describe('With truthy sessionKeyInQueryString flag...', () => {
-    test('should have empty headers', () => {});
-    test('should have sessionKey in query params', () => {});
-  });
-
-  describe('With falsy sessionKeyInQueryString flag...', () => {
-    test('should have X-SESSION header', () => {});
-    test('should have no sessionKey in query params', () => {});
-  });
-
   describe('With concurrent calls by one same client...', () => {
     const onSessionKeyChangedB = jest.fn();
     const clientB = factory({

--- a/test/specs/sessionKeyInQueryString.spec.js
+++ b/test/specs/sessionKeyInQueryString.spec.js
@@ -1,0 +1,62 @@
+const factory = require('../../src/node/index');
+const fetch = require('isomorphic-unfetch');
+
+const idToFetch = '56ea7bd6935f75032a2fd431';
+
+const makeClient = sessionKeyInQueryString =>
+  factory({
+    appKey: '56ea6a370db1bf032c9df5cb',
+    deviceId: 'gregTestingSDK',
+    sessionKeyInQueryString,
+  });
+
+const hasSessionQS = mock => {
+  return mock.calls.some(
+    ([arg0]) => arg0.includes('?sessionKey=') || arg0.includes('&sessionKey=')
+  );
+};
+
+const hasSessionHeader = mock => {
+  return mock.calls.some(([, arg1 = {}]) => {
+    const { headers = {} } = arg1;
+    return headers['X-SESSION'];
+  });
+};
+
+describe('"sessionKeyInQueryString" flag Tests...', () => {
+  describe('With truthy sessionKeyInQueryString flag...', () => {
+    const client = makeClient(true);
+
+    test('should have empty headers', () => {
+      fetch.mockClear();
+      return client.getEntryById(idToFetch).then(() => {
+        expect(hasSessionHeader(fetch.mock)).toBeFalsy();
+      });
+    });
+
+    test('should have sessionKey in query params', () => {
+      fetch.mockClear();
+      return client.getEntryById(idToFetch).then(() => {
+        expect(hasSessionQS(fetch.mock)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('With falsy sessionKeyInQueryString flag...', () => {
+    const client = makeClient(false);
+
+    test('should have "X-SESSION" header', () => {
+      fetch.mockClear();
+      return client.getEntryById(idToFetch).then(() => {
+        expect(hasSessionHeader(fetch.mock)).toBeTruthy();
+      });
+    });
+
+    test('should have no "sessionKey" in query params', () => {
+      fetch.mockClear();
+      return client.getEntryById(idToFetch).then(() => {
+        expect(hasSessionQS(fetch.mock)).toBeFalsy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### SUMMARY
Addition of `sessionKeyInQueryString` flag in accedo client instantiation config.
When truthy, `sessionKey` will be passed in query string instead of as an `X-SESSION` header.