### PR TITLE
Feature/apiHelper without destructuring

### DIFF
--- a/src/stamps/appLogCommon.js
+++ b/src/stamps/appLogCommon.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { grab, post } = require('../apiHelper');
+const api = require('../apiHelper');
 
 const DEBUG = 'debug';
 const INFO = 'info';
@@ -24,12 +24,12 @@ const getLogEvent = (details = {}, metadata) => {
 };
 
 function request(path) {
-  return this.withSessionHandling(() => grab(path, this.config));
+  return this.withSessionHandling(() => api.grab(path, this.config));
 }
 
 function postLogs(logs) {
   return this.withSessionHandling(() =>
-    post('/application/logs', this.config, logs)
+    api.post('/application/logs', this.config, logs)
   );
 }
 

--- a/src/stamps/application.js
+++ b/src/stamps/application.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 // Make sure we have the sessionStamp withSessionHandling method
 const stamp = sessionStamp.compose({
@@ -9,7 +9,7 @@ const stamp = sessionStamp.compose({
      * @return {promise}  a promise of the application status (string)
      */
     getApplicationStatus() {
-      return this.withSessionHandling(() => grab('/status', this.config));
+      return this.withSessionHandling(() => api.grab('/status', this.config));
     },
   },
 });

--- a/src/stamps/assets.js
+++ b/src/stamps/assets.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 // Make sure we have the sessionStamp withSessionHandling method
 const stamp = sessionStamp.compose({
@@ -9,7 +9,7 @@ const stamp = sessionStamp.compose({
      * @return {promise}  a promise of a hash of assets (key: asset name, value: asset URL)
      */
     getAllAssets() {
-      return this.withSessionHandling(() => grab('/asset', this.config));
+      return this.withSessionHandling(() => api.grab('/asset', this.config));
     },
   },
 });

--- a/src/stamps/entries.js
+++ b/src/stamps/entries.js
@@ -1,6 +1,6 @@
 const qs = require('qs');
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 function getPathWithQs(path, params = {}) {
   const {
@@ -46,7 +46,7 @@ function getPathWithQs(path, params = {}) {
 
 function request(path, params) {
   const pathWithQs = getPathWithQs(path, params);
-  return this.withSessionHandling(() => grab(pathWithQs, this.config));
+  return this.withSessionHandling(() => api.grab(pathWithQs, this.config));
 }
 
 // Make sure we have the sessionStamp withSessionHandling method AND appLogCommon

--- a/src/stamps/events.js
+++ b/src/stamps/events.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { post } = require('../apiHelper');
+const api = require('../apiHelper');
 
 function sendUsageEvent(eventType, retentionTime) {
   const payload = { eventType };
@@ -7,7 +7,7 @@ function sendUsageEvent(eventType, retentionTime) {
     payload.retentionTime = retentionTime;
   }
   return this.withSessionHandling(() =>
-    post('/event/log', this.config, payload)
+    api.post('/event/log', this.config, payload)
   );
 }
 

--- a/src/stamps/locales.js
+++ b/src/stamps/locales.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 // Make sure we have the sessionStamp withSessionHandling method
 const stamp = sessionStamp.compose({
@@ -9,7 +9,7 @@ const stamp = sessionStamp.compose({
      * @return {promise}  a promise of the requested data
      */
     getAvailableLocales() {
-      return this.withSessionHandling(() => grab('/locales', this.config));
+      return this.withSessionHandling(() => api.grab('/locales', this.config));
     },
   },
 });

--- a/src/stamps/metadata.js
+++ b/src/stamps/metadata.js
@@ -1,8 +1,8 @@
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 function request(path) {
-  return this.withSessionHandling(() => grab(path, this.config));
+  return this.withSessionHandling(() => api.grab(path, this.config));
 }
 
 // Make sure we have the sessionStamp withSessionHandling method

--- a/src/stamps/plugins.js
+++ b/src/stamps/plugins.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 // Make sure we have the sessionStamp withSessionHandling method
 const stamp = sessionStamp.compose({
@@ -9,7 +9,7 @@ const stamp = sessionStamp.compose({
      * @return {promise}  a promise of the requested data
      */
     getAllEnabledPlugins() {
-      return this.withSessionHandling(() => grab('/plugins', this.config));
+      return this.withSessionHandling(() => api.grab('/plugins', this.config));
     },
   },
 });

--- a/src/stamps/profile.js
+++ b/src/stamps/profile.js
@@ -1,5 +1,5 @@
 const sessionStamp = require('./session');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 // Make sure we have the sessionStamp withSessionHandling method
 const stamp = sessionStamp.compose({
@@ -9,7 +9,7 @@ const stamp = sessionStamp.compose({
      * @return {promise}  a promise of the requested data
      */
     getProfileInfo() {
-      return this.withSessionHandling(() => grab('/profile', this.config));
+      return this.withSessionHandling(() => api.grab('/profile', this.config));
     },
   },
 });

--- a/src/stamps/session.js
+++ b/src/stamps/session.js
@@ -1,5 +1,5 @@
 const stampit = require('@stamp/it');
-const { grab } = require('../apiHelper');
+const api = require('../apiHelper');
 
 // Make sure we have the sessionStamp withSessionHandling method AND appLogCommon
 const stamp = stampit({
@@ -24,7 +24,8 @@ const stamp = stampit({
       }
 
       // launch a request, update the promise
-      creatingSessionPromise = grab('/session', instance.config)
+      creatingSessionPromise = api
+        .grab('/session', instance.config)
         .then(json => {
           const { sessionKey } = json;
           // update the context of this client, adding the session key

--- a/src/stamps/userData.js
+++ b/src/stamps/userData.js
@@ -1,15 +1,15 @@
 const sessionStamp = require('./session');
-const { grab, post } = require('../apiHelper');
+const api = require('../apiHelper');
 
 const APPLICATION_SCOPE = 'user';
 const APPLICATION_GROUP_SCOPE = 'group';
 
 function requestGet(path) {
-  return this.withSessionHandling(() => grab(path, this.config));
+  return this.withSessionHandling(() => api.grab(path, this.config));
 }
 
 function requestPost(path, data) {
-  return this.withSessionHandling(() => post(path, this.config, data));
+  return this.withSessionHandling(() => api.post(path, this.config, data));
 }
 
 function getAllDataByUser(scope, userName) {


### PR DESCRIPTION
### Summary 

`jest.spyOn` (docs [here](https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname)) works by tracking calls to `object[methodName]`.
This forces us to avoid destructuring, in order to have a parent object with a `grab` method to spy.