### PR TITLE
Feature/handle global session refresh

### DIFF
--- a/src/stamps/session.js
+++ b/src/stamps/session.js
@@ -83,6 +83,17 @@ const stamp = stampit({
     },
 
     /**
+     * Cleans the global invalid session if useSharedSession flag is active,
+     * in order to avoid resolving the old global session promise in createSession
+     * @returns {void}
+     */
+    cleanInvalidSession() {
+      if (this.config.useSharedSession) {
+        setGlobalSession(null);
+      }
+    },
+
+    /**
      * If a sessionKey exists, calls the next function, then:
      * - If this failed with a 401 (unauthorized), create a session then retry
      * - Otherwise returns a promise of that function's results
@@ -96,6 +107,8 @@ const stamp = stampit({
       if (this.getSessionKey()) {
         return next().catch(res => {
           if (res && res.status === 401) {
+            // clean global session when necessary
+            this.cleanInvalidSession();
             // session expired - recreate one then retry
             return this.createSession().then(next);
           }

--- a/test/specs/sessionCalls.spec.js
+++ b/test/specs/sessionCalls.spec.js
@@ -78,4 +78,22 @@ describe('Session service calls Tests...', () => {
         });
     });
   });
+
+  describe('After session invalidation...', () => {
+    test('should invalidate and refresh global session, with truthy `useSharedSession`', () => {
+      resetGlobalSession();
+      fetch.mockClear();
+      const client = makeClient(true);
+      return client
+        .getAllMetadata()
+        .then(() => {
+          client.config.sessionKey = 'invalidSessionKey';
+          setGlobalSession(Promise.resolve('invalidSessionKey'));
+          return client.getAllMetadata();
+        })
+        .then(() => {
+          expect(getNumberOfSessionCalls(fetch.mock)).toBe(2);
+        });
+    });
+  });
 });


### PR DESCRIPTION
### SUMMARY
This PR solves an issue that happens upon accedo session invalidation, when `useSharedSession` flag is truthy.

### IMPLEMENTATION
Addition of `cleanInvalidSession` fn in session stamp, in order to clean the global invalid session - after receiving a 401 from accedo service - (& only if `useSharedSession` flag is active), to avoid resolving the old invalid global session promise in the next `createSession` call